### PR TITLE
Add CLI and controller modules

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,3 +4,4 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+clap = { version = "4.4", features = ["derive"] }

--- a/src/controller/mod.rs
+++ b/src/controller/mod.rs
@@ -1,0 +1,3 @@
+pub mod atmospheric_control;
+pub mod resonance_router;
+pub mod terraforming_engine;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,37 @@
+use clap::{Parser, Subcommand};
+
+mod controller;
+
+/// Command-line interface definition using Clap.
+#[derive(Parser)]
+#[command(name = "NessHash", version = "0.1.0", author = "NessHash Team")]
+struct Cli {
+    /// Optional subcommand to run a specific controller
+    #[command(subcommand)]
+    command: Option<Commands>,
+}
+
+/// Available subcommands for granular control over the system.
+#[derive(Subcommand)]
+enum Commands {
+    /// Boot the entire terraforming flow
+    Boot,
+    /// Trigger the atmospheric regulation cycle only
+    Regulate,
+    /// Route resonance waves without starting other systems
+    Route,
+}
+
 fn main() {
-    println!("NessHash core booting...");
+    let cli = Cli::parse();
+    match cli.command.unwrap_or(Commands::Boot) {
+        Commands::Boot => {
+            println!("NessHash core booting...");
+            controller::terraforming_engine::initiate();
+            controller::atmospheric_control::regulate();
+            controller::resonance_router::route();
+        }
+        Commands::Regulate => controller::atmospheric_control::regulate(),
+        Commands::Route => controller::resonance_router::route(),
+    }
 }


### PR DESCRIPTION
## Summary
- add Clap dependency
- implement CLI with subcommands
- expose controller modules

## Testing
- `cargo build --release`
- `cargo test --release`


------
https://chatgpt.com/codex/tasks/task_e_688c9d71fe3c8325b2ceaf5fc71eae7b